### PR TITLE
RGB speed reduce working

### DIFF
--- a/keyboards/gmmk/pro/ansi/keymaps/stickandgum/keymap.c
+++ b/keyboards/gmmk/pro/ansi/keymaps/stickandgum/keymap.c
@@ -56,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       LED_TILDE, LED_1,  LED_2,   LED_3,   LED_4,    LED_5,   LED_6,   LED_7,   LED_8,   LED_9,   LED_0,   LED_MINS, LED_EQL,  KC_INS,         KC_SLCK,
         _______, RGB_SAI, RGB_VAI, RGB_HUI, RGB_TOG,  _______, _______, _______, _______, _______, _______, _______, _______, RESET,           KC_BRIU,
        _______, RGB_RMOD, RGB_VAD, RGB_MOD, RGB_SPI, _______,  _______, _______, _______, QMKBEST, _______, _______,         _______,          KC_BRID,
-        _______,          _______, _______, _______, _______,  _______, NK_TOGG, _______, _______, _______, _______,         _______, KC_MPLY, KC_PWR,
+        RGB_SPD,          _______, _______, _______, _______,  _______, NK_TOGG, _______, _______, _______, _______,         _______, KC_MPLY, KC_PWR,
         _______, _______, _______,                             _______,                            KC_RALT, _______, KC_APP, KC_MPRV, KC_MSTP, KC_MNXT
     ),
 


### PR DESCRIPTION
Couldn't figure out why the RGB speed slowdown wasn't working and I saw it looks like that mapping wasn't there. I wasn't sure where to submit this PR (against the official QMK repo or here) but decided to make it here in case there's something that I'm missing.